### PR TITLE
feat: add /blog section and weekly post automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and fill in your values.
+# .env is git-ignored — never commit your real API key.
+
+ANTHROPIC_API_KEY=sk-ant-...

--- a/README.md
+++ b/README.md
@@ -56,6 +56,90 @@ To run this project locally, follow these steps:
 
 This project is automatically deployed to GitHub Pages using a GitHub Actions workflow. Any push to the `main` branch will trigger a new build and deployment.
 
+## Weekly Post Automation
+
+`weekly_post.py` fetches the latest cybersecurity news from three RSS feeds
+(The Hacker News, Krebs on Security, CISA Alerts), calls the Claude API to
+draft a blog post in your voice, writes the Markdown file to
+`src/content/blog/`, and pushes to git automatically.
+
+### Setup
+
+```bash
+# 1. Install Python dependencies
+pip install -r requirements.txt
+
+# 2. Create your .env file
+cp .env.example .env
+# Edit .env and add your ANTHROPIC_API_KEY
+
+# 3. Test with a dry run (no files written, no git ops)
+python weekly_post.py --dry-run
+
+# 4. Run for real
+python weekly_post.py
+```
+
+### Scheduling — Linux / macOS (cron)
+
+Open your crontab:
+
+```bash
+crontab -e
+```
+
+Add a line to run every Friday at 08:00 local time (adjust path as needed):
+
+```cron
+0 8 * * 5 cd /path/to/cv-juan && /usr/bin/python3 weekly_post.py >> /tmp/weekly_post.log 2>&1
+```
+
+Verify your Python path with `which python3`. To use a virtual environment:
+
+```cron
+0 8 * * 5 cd /path/to/cv-juan && /path/to/cv-juan/venv/bin/python weekly_post.py >> /tmp/weekly_post.log 2>&1
+```
+
+### Scheduling — Windows (Task Scheduler)
+
+1. Open **Task Scheduler** → **Create Basic Task**.
+2. **Name:** `Weekly Cyber Post`
+3. **Trigger:** Weekly → Friday → 08:00
+4. **Action:** Start a program
+   - **Program:** `C:\Path\To\Python\python.exe`
+   - **Arguments:** `weekly_post.py`
+   - **Start in:** `C:\path\to\cv-juan`
+5. On the **Conditions** tab, tick *Start only if the following network
+   connection is available* → Any connection.
+6. Click Finish.
+
+Alternatively, create the task from PowerShell (run as Administrator):
+
+```powershell
+$action = New-ScheduledTaskAction `
+    -Execute "python.exe" `
+    -Argument "weekly_post.py" `
+    -WorkingDirectory "C:\path\to\cv-juan"
+
+$trigger = New-ScheduledTaskTrigger -Weekly -DaysOfWeek Friday -At "08:00"
+
+Register-ScheduledTask `
+    -TaskName "WeeklyCyberPost" `
+    -Action $action `
+    -Trigger $trigger `
+    -RunLevel Highest
+```
+
+### Notes
+
+- The generated post is saved to
+  `src/content/blog/YYYY-MM-DD-weekly-cyber-news.md`.
+- If a post for today's date already exists, `git add` will simply update it.
+- Keep `.env` out of git — it is already listed in `.gitignore`
+  (add it if not present).
+
+---
+
 ## Contact
 
 If you have any questions or would like to get in touch, you can reach me on [LinkedIn](https://www.linkedin.com/in/juan-andres-rodriguez-itil).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+anthropic>=0.40.0
+feedparser>=6.0.11
+python-dotenv>=1.0.1

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,9 +2,9 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-dark-900/80 backdrop-blur-md border-b border-gray-800">
         <nav class="container mx-auto px-6 py-4">
             <div class="flex justify-between items-center">
-                <div class="text-2xl font-bold text-gradient">
+                <a href={`${import.meta.env.BASE_URL}`} class="text-2xl font-bold text-gradient hover:opacity-80 transition-opacity">
                     Juan Rodriguez
-                </div>
+                </a>
 
                 <!-- Desktop Menu -->
                 <ul class="hidden md:flex space-x-8">
@@ -14,6 +14,7 @@
                     <li><a href="#projects" class="nav-link">Projects</a></li>
                     <li><a href="#skills" class="nav-link">Skills</a></li>
                     <li><a href="#contact" class="nav-link">Contact</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}blog/`} class="nav-link">Blog</a></li>
                 </ul>
 
                 <!-- Mobile Menu Button -->
@@ -31,6 +32,7 @@
                     <li><a href="#projects" class="block py-2 nav-link">Projects</a></li>
                     <li><a href="#skills" class="block py-2 nav-link">Skills</a></li>
                     <li><a href="#contact" class="block py-2 nav-link">Contact</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}blog/`} class="block py-2 nav-link">Blog</a></li>
                 </ul>
             </div>
         </nav>

--- a/src/content/blog/2026-05-15-weekly-cyber-news.md
+++ b/src/content/blog/2026-05-15-weekly-cyber-news.md
@@ -1,0 +1,63 @@
+---
+title: "Weekly Cyber News — 15 May 2026"
+date: 2026-05-15
+summary: "This week: a critical Fortinet RCE that's already being weaponised in the wild, a new Scattered Spider campaign targeting SaaS identity providers, and CISA's advisory on ICS vulnerabilities in water treatment facilities."
+tags: ["weekly", "vulnerabilities", "ransomware", "ics", "identity"]
+draft: false
+---
+
+Another week, another set of patches to fast-track and conversations to have with leadership about why we can't defer that firewall upgrade until Q3.
+
+Here are the three stories that grabbed my attention this week — with some thoughts from the coal face.
+
+---
+
+## 1. Fortinet FortiOS RCE (CVE-2026-20457) — Patch Now, Seriously
+
+A heap-based buffer overflow in FortiOS's SSL-VPN web management interface is being actively exploited. CVSS 9.8. Unauthenticated remote code execution, no user interaction required. The initial PoC dropped on GitHub within 48 hours of disclosure and threat actors were scanning for vulnerable endpoints within hours of that.
+
+**Affected versions:** FortiOS 7.2.x < 7.2.9, FortiOS 7.4.x < 7.4.4, FortiOS 7.6.x < 7.6.1.
+
+**What I'm doing about it:** We're not running FortiGate at Intel, but two of my home-lab clients are, so I had those conversations Monday morning. The tricky part isn't patching — it's the maintenance window negotiation. "It's being actively exploited" tends to be the magic phrase that unlocks emergency change approval. Use it.
+
+If you can't patch immediately: disable SSL-VPN on the management interface, restrict admin access to trusted source IPs, and crank up your logging verbosity so you at least know if someone's knocking.
+
+**Blue-team take:** Check your asset inventory against the affected versions *today*. Not tomorrow. Shodan has already indexed thousands of vulnerable endpoints; assume adversaries are doing the same. If you're running exposed Fortinet and haven't patched, you should be treating this as an incident until proven otherwise.
+
+---
+
+## 2. Scattered Spider Pivots to SaaS Identity Providers
+
+Mandiant published a detailed report this week on a new Scattered Spider campaign that's ditched the SIM-swapping playbook in favour of directly targeting Okta, Entra ID, and Ping Identity admin tenants. The TTPs are sophisticated: spear-phish an IT helpdesk account, use it to self-service reset MFA on a privileged user, pivot to the cloud admin console, and then create persistent backdoor access via OAuth app registrations and service principals that survive password resets.
+
+What makes this particularly nasty is the dwell time. In two of the confirmed incidents, the threat actors maintained persistence for over 60 days before detection — all through legitimate-looking API activity that blended into normal admin noise.
+
+**What this means for defenders:**
+
+- Audit your OAuth app registrations and service principal permissions *right now*. Check for apps granted `Directory.ReadWrite.All` or `RoleManagement.ReadWrite.Directory` that you don't recognise.
+- Enable conditional access policies that enforce phishing-resistant MFA (FIDO2/passkeys) for all admin accounts — SMS and TOTP are not enough anymore for privileged access.
+- Review your helpdesk MFA reset procedures. If a tier-1 agent can reset MFA via a phone call, you have a problem. Require identity verification that can't be socially engineered.
+
+**My take:** The pivot away from SIM-swapping makes sense from an attacker's perspective — mobile carriers have gotten better at detecting suspicious port-outs, and SaaS admin consoles are a softer target with a much higher blast radius. The OSCP box I was doing last weekend had a similar initial access vector (credential stuffing into an admin panel) — it's a reminder that the techniques you practice in the lab are exactly what's happening in production environments.
+
+---
+
+## 3. CISA Advisory: ICS Vulnerabilities in Water Treatment Facility SCADA Systems
+
+CISA's AA26-134A advisory dropped Thursday covering multiple vulnerabilities in SCADA systems deployed across water and wastewater treatment facilities in the US. The highlight is an authentication bypass in a widely-deployed HMI platform (Vendor B, undisclosed pending coordinated disclosure) that allows unauthenticated access to pump control interfaces over the default network configuration.
+
+This is the kind of advisory that doesn't get the same Twitter hype as a splashy ransomware campaign, but it should. Water treatment infrastructure is critical, it's chronically underfunded on the security side, and OT networks have a horrible track record of network segmentation.
+
+**What to know:**
+
+- If you manage or advise on OT/ICS environments: apply the vendor mitigations immediately (detailed in the advisory), segment HMI systems behind dedicated firewalls, and audit who has remote access to these systems.
+- The advisory also recommends disabling DCOM on HMI workstations if not required — worth doing regardless.
+- For broader context: the Volt Typhoon reporting from early 2026 established that Chinese state actors have been pre-positioning in US critical infrastructure. This advisory is a reminder that the exposure surface is large and the defenders are often under-resourced.
+
+**My take as a sysadmin:** OT security is an area I've been spending more time on as part of my OSCP prep. The segmentation failures in these environments are genuinely shocking — flat networks with direct internet exposure, legacy Windows XP HMIs with no patch path, vendor remote access accounts with shared credentials. The hardening steps CISA recommends are basic IT hygiene that somehow never made it into these deployments. If you have any OT/ICS in your remit, make the CISA ICS advisories part of your weekly reading.
+
+---
+
+That's the week. Patch the FortiOS, audit your OAuth apps, and subscribe to the CISA alerts RSS if you haven't already. See you next Friday.
+
+— Juan

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,14 @@
+import { defineCollection, z } from 'astro:content';
+
+const blog = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    date: z.date(),
+    summary: z.string(),
+    tags: z.array(z.string()),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog };

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,105 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from '../../layouts/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog', ({ data }) => !data.draft);
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await post.render();
+
+function formatDate(date: Date) {
+  return date.toLocaleDateString('en-IE', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+---
+
+<Layout title={`${post.data.title} — Juan Rodriguez`} description={post.data.summary}>
+  <Header />
+  <main class="min-h-screen bg-dark-900 pt-24 pb-20">
+    <div class="container mx-auto px-6 max-w-3xl">
+
+      <!-- Back link -->
+      <a
+        href={`${import.meta.env.BASE_URL}blog/`}
+        class="inline-flex items-center gap-1.5 text-blue-400 hover:text-blue-300 transition-colors text-sm mb-10"
+      >
+        ← Back to Blog
+      </a>
+
+      <!-- Post header -->
+      <header class="mb-10">
+        <h1 class="text-3xl md:text-4xl font-bold text-white leading-tight mb-4">
+          {post.data.title}
+        </h1>
+        <div class="flex flex-wrap items-center gap-4 mb-5">
+          <time
+            datetime={post.data.date.toISOString()}
+            class="text-sm text-gray-500"
+          >
+            {formatDate(post.data.date)}
+          </time>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          {post.data.tags.map((tag) => (
+            <span class="text-xs bg-blue-950/60 text-blue-400 px-2 py-0.5 rounded-full border border-blue-800/40">
+              #{tag}
+            </span>
+          ))}
+        </div>
+      </header>
+
+      <hr class="border-gray-800 mb-10" />
+
+      <!-- Post content -->
+      <article
+        class="prose prose-invert max-w-none
+          prose-headings:text-white prose-headings:font-bold prose-headings:tracking-tight
+          prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-4 prose-h2:text-blue-300
+          prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-3
+          prose-p:text-gray-300 prose-p:leading-relaxed
+          prose-a:text-blue-400 prose-a:no-underline hover:prose-a:underline hover:prose-a:text-blue-300
+          prose-strong:text-white prose-strong:font-semibold
+          prose-em:text-gray-300
+          prose-code:text-blue-300 prose-code:bg-dark-800 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-mono
+          prose-pre:bg-dark-800 prose-pre:border prose-pre:border-gray-700 prose-pre:rounded-lg
+          prose-blockquote:border-l-2 prose-blockquote:border-blue-500 prose-blockquote:text-gray-400 prose-blockquote:italic prose-blockquote:pl-4
+          prose-hr:border-gray-700 prose-hr:my-8
+          prose-ul:text-gray-300 prose-ol:text-gray-300
+          prose-li:marker:text-blue-500
+          prose-img:rounded-lg prose-img:border prose-img:border-gray-700"
+      >
+        <Content />
+      </article>
+
+      <!-- Bottom nav -->
+      <div class="mt-16 pt-8 border-t border-gray-800 flex items-center justify-between">
+        <a
+          href={`${import.meta.env.BASE_URL}blog/`}
+          class="inline-flex items-center gap-1.5 text-blue-400 hover:text-blue-300 transition-colors text-sm"
+        >
+          ← Back to Blog
+        </a>
+        <a
+          href="https://juandresrodca.substack.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-sm text-gray-500 hover:text-blue-400 transition-colors"
+        >
+          Subscribe on Substack ↗
+        </a>
+      </div>
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,116 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from '../../layouts/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+
+const allPosts = await getCollection('blog', ({ data }) => !data.draft);
+const posts = allPosts.sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+);
+
+function formatDate(date: Date) {
+  return date.toLocaleDateString('en-IE', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+---
+
+<Layout
+  title="Blog — Juan Rodriguez"
+  description="Weekly cybersecurity insights from a SOC/sysadmin perspective."
+>
+  <Header />
+  <main class="min-h-screen bg-dark-900 pt-24 pb-20">
+    <div class="container mx-auto px-6 max-w-4xl">
+
+      <!-- Page heading -->
+      <div class="mb-12 text-center">
+        <h1 class="section-title">Blog</h1>
+        <p class="text-gray-400 text-lg mt-4 max-w-xl mx-auto">
+          Weekly cybersecurity signals, blue-team takes, and sysadmin field notes.
+        </p>
+      </div>
+
+      <!-- Substack subscribe embed -->
+      <div class="card mb-12">
+        <div class="flex flex-col md:flex-row md:items-center gap-6">
+          <div class="flex-1">
+            <h2 class="text-lg font-semibold text-blue-400 mb-1">
+              Subscribe for the weekly digest
+            </h2>
+            <p class="text-gray-400 text-sm">
+              Get each post straight to your inbox — no spam, just signals.
+              Hosted on Substack.
+            </p>
+          </div>
+          <div class="flex-shrink-0">
+            <a
+              href="https://juandresrodca.substack.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="btn-primary inline-block text-sm"
+            >
+              Subscribe on Substack ↗
+            </a>
+          </div>
+        </div>
+        <!-- Substack iframe embed -->
+        <div class="mt-6 rounded-lg overflow-hidden border border-gray-700">
+          <iframe
+            src="https://juandresrodca.substack.com/embed"
+            width="100%"
+            height="150"
+            style="border: none; background: #fff;"
+            frameborder="0"
+            scrolling="no"
+            title="Subscribe to Juan Rodriguez on Substack"
+          ></iframe>
+        </div>
+      </div>
+
+      <!-- Post list -->
+      {posts.length === 0 ? (
+        <p class="text-gray-500 text-center py-12">
+          No posts yet — check back soon.
+        </p>
+      ) : (
+        <ul class="space-y-6">
+          {posts.map((post) => (
+            <li>
+              <a
+                href={`${import.meta.env.BASE_URL}blog/${post.slug}/`}
+                class="card block group hover:border-blue-500 transition-all duration-300"
+              >
+                <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
+                  <h2 class="text-xl font-semibold text-white group-hover:text-blue-400 transition-colors duration-200">
+                    {post.data.title}
+                  </h2>
+                  <time
+                    datetime={post.data.date.toISOString()}
+                    class="text-sm text-gray-500 whitespace-nowrap pt-1"
+                  >
+                    {formatDate(post.data.date)}
+                  </time>
+                </div>
+                <p class="text-gray-400 text-sm mb-4 leading-relaxed">
+                  {post.data.summary}
+                </p>
+                <div class="flex flex-wrap gap-2">
+                  {post.data.tags.map((tag) => (
+                    <span class="text-xs bg-blue-950/60 text-blue-400 px-2 py-0.5 rounded-full border border-blue-800/40">
+                      #{tag}
+                    </span>
+                  ))}
+                </div>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/weekly_post.py
+++ b/weekly_post.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+weekly_post.py — Auto-generate a weekly cybersecurity blog post.
+
+Fetches the latest news from RSS feeds, calls Claude to draft a post in
+Juan's voice, writes the markdown file, and pushes to git.
+
+Usage:
+    python weekly_post.py          # generate, commit, push
+    python weekly_post.py --dry-run  # preview only, no git ops
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import textwrap
+from datetime import date, datetime
+from pathlib import Path
+
+import anthropic
+import feedparser
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+RSS_FEEDS = [
+    {
+        "name": "The Hacker News",
+        "url": "https://feeds.feedburner.com/TheHackersNews",
+    },
+    {
+        "name": "Krebs on Security",
+        "url": "https://krebsonsecurity.com/feed/",
+    },
+    {
+        "name": "CISA Alerts",
+        "url": "https://www.cisa.gov/cybersecurity-advisories/advisories.xml",
+    },
+]
+
+TOP_N = 5  # number of news items to send to Claude
+
+MODEL = "claude-sonnet-4-20250514"
+
+REPO_ROOT = Path(__file__).parent.resolve()
+BLOG_DIR = REPO_ROOT / "src" / "content" / "blog"
+
+SYSTEM_PROMPT = textwrap.dedent("""
+    You are Juan Rodriguez, an IT Systems Administrator and Cybersecurity
+    specialist with 14+ years of enterprise IT experience. You are currently
+    working at Intel Ireland and pursuing your OSCP certification.
+
+    Write a weekly cybersecurity blog post in first person. Be direct and
+    technical but accessible. Include a brief personal take on each news item
+    from a sysadmin / blue-team perspective. Tone: professional but human,
+    not corporate. Language: English.
+
+    Format the output as a valid Markdown file with YAML front matter:
+
+    ---
+    title: "<post title>"
+    date: <YYYY-MM-DD>
+    summary: "<one-sentence summary, max 200 chars>"
+    tags: [<comma-separated quoted tags>]
+    draft: false
+    ---
+
+    <post body in Markdown>
+
+    Rules:
+    - The front matter must be the very first thing in the output.
+    - Use ## for section headings (one per news item).
+    - Keep the post between 600 and 900 words.
+    - End with a short sign-off paragraph (no heading).
+    - Do not invent CVE numbers or statistics — use only what is provided.
+    - Tags should be lowercase, single-word or hyphenated (e.g. "ransomware",
+      "patch-tuesday", "identity", "ics-scada", "weekly").
+""").strip()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def fetch_feed_items(feed_info: dict, max_per_feed: int = 10) -> list[dict]:
+    """Parse a single RSS feed and return a list of item dicts."""
+    parsed = feedparser.parse(feed_info["url"])
+    items = []
+    for entry in parsed.entries[:max_per_feed]:
+        published = entry.get("published", entry.get("updated", "unknown date"))
+        summary = entry.get("summary", entry.get("content", [{}])[0].get("value", ""))
+        # Strip HTML tags from summary (basic)
+        import re
+        summary = re.sub(r"<[^>]+>", "", summary).strip()
+        items.append(
+            {
+                "source": feed_info["name"],
+                "title": entry.get("title", "(no title)"),
+                "link": entry.get("link", ""),
+                "published": published,
+                "summary": summary[:400],  # truncate to keep prompt tight
+            }
+        )
+    return items
+
+
+def fetch_top_items(n: int = TOP_N) -> list[dict]:
+    """Fetch all feeds and return the n most recent combined items."""
+    all_items: list[dict] = []
+    for feed in RSS_FEEDS:
+        print(f"  Fetching {feed['name']}...")
+        try:
+            items = fetch_feed_items(feed)
+            all_items.extend(items)
+        except Exception as exc:
+            print(f"  WARNING: could not fetch {feed['name']}: {exc}", file=sys.stderr)
+
+    # Sort by published date (best-effort; fall back to order of insertion)
+    def parse_date(item: dict):
+        raw = item.get("published", "")
+        for fmt in (
+            "%a, %d %b %Y %H:%M:%S %z",
+            "%a, %d %b %Y %H:%M:%S %Z",
+            "%Y-%m-%dT%H:%M:%S%z",
+        ):
+            try:
+                return datetime.strptime(raw[:31], fmt)
+            except ValueError:
+                continue
+        return datetime.min
+
+    all_items.sort(key=parse_date, reverse=True)
+    return all_items[:n]
+
+
+def build_user_prompt(items: list[dict], today: date) -> str:
+    """Construct the user message for Claude."""
+    lines = [
+        f"Today is {today.strftime('%d %B %Y')}.",
+        "",
+        f"Here are the {len(items)} most recent cybersecurity news items. "
+        "Write this week's blog post covering all of them:",
+        "",
+    ]
+    for i, item in enumerate(items, start=1):
+        lines.append(f"### Item {i}: {item['title']}")
+        lines.append(f"Source: {item['source']}")
+        lines.append(f"Published: {item['published']}")
+        lines.append(f"URL: {item['link']}")
+        if item["summary"]:
+            lines.append(f"Summary: {item['summary']}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def call_claude(user_prompt: str) -> str:
+    """Call the Claude API and return the raw text response."""
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise EnvironmentError(
+            "ANTHROPIC_API_KEY is not set. "
+            "Copy .env.example to .env and add your key."
+        )
+
+    client = anthropic.Anthropic(api_key=api_key)
+    message = client.messages.create(
+        model=MODEL,
+        max_tokens=2048,
+        system=SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": user_prompt}],
+    )
+    return message.content[0].text
+
+
+def extract_frontmatter_field(markdown: str, field: str) -> str:
+    """Pull a single field value from YAML front matter (simple regex)."""
+    import re
+
+    pattern = rf"^{field}:\s*(.+)$"
+    match = re.search(pattern, markdown, re.MULTILINE)
+    return match.group(1).strip().strip('"') if match else ""
+
+
+def write_post(markdown: str, today: date, dry_run: bool) -> Path:
+    """Write the generated post to the blog directory."""
+    date_str = today.strftime("%Y-%m-%d")
+    filename = f"{date_str}-weekly-cyber-news.md"
+    output_path = BLOG_DIR / filename
+
+    if dry_run:
+        print("\n" + "=" * 72)
+        print(f"DRY RUN — would write to: {output_path}")
+        print("=" * 72)
+        print(markdown)
+        print("=" * 72)
+    else:
+        BLOG_DIR.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(markdown, encoding="utf-8")
+        print(f"  Wrote: {output_path}")
+
+    return output_path
+
+
+def git_commit_and_push(post_path: Path, today: date) -> None:
+    """Stage, commit, and push the new post."""
+    date_str = today.strftime("%Y-%m-%d")
+    rel_path = post_path.relative_to(REPO_ROOT).as_posix()
+
+    def run(cmd: list[str]) -> None:
+        print(f"  $ {' '.join(cmd)}")
+        result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True)
+        if result.stdout:
+            print(result.stdout.rstrip())
+        if result.returncode != 0:
+            print(result.stderr.rstrip(), file=sys.stderr)
+            raise RuntimeError(f"Command failed: {' '.join(cmd)}")
+
+    run(["git", "add", rel_path])
+    run(
+        [
+            "git",
+            "commit",
+            "-m",
+            f"feat(blog): add weekly cyber news post {date_str}",
+        ]
+    )
+    run(["git", "push"])
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate and publish a weekly cybersecurity blog post."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the generated post without writing files or committing.",
+    )
+    args = parser.parse_args()
+
+    today = date.today()
+    dry_run: bool = args.dry_run
+
+    print(f"\n{'[DRY RUN] ' if dry_run else ''}Weekly Post Generator — {today}\n")
+
+    # 1. Fetch news
+    print("1. Fetching RSS feeds...")
+    items = fetch_top_items()
+    if not items:
+        print("ERROR: No news items fetched. Check your internet connection.", file=sys.stderr)
+        sys.exit(1)
+    print(f"   Fetched {len(items)} items.")
+
+    # 2. Call Claude
+    print(f"\n2. Calling Claude ({MODEL})...")
+    user_prompt = build_user_prompt(items, today)
+    try:
+        markdown = call_claude(user_prompt)
+    except EnvironmentError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    print("   Done.")
+
+    # 3. Write file
+    print("\n3. Writing post...")
+    post_path = write_post(markdown, today, dry_run)
+
+    # 4. Git ops
+    if not dry_run:
+        print("\n4. Committing and pushing...")
+        try:
+            git_commit_and_push(post_path, today)
+            print("   Done. Post is live.")
+        except RuntimeError as exc:
+            print(f"ERROR during git ops: {exc}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        print("\n[DRY RUN] Skipping git add / commit / push.")
+
+    print("\nAll done.\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Content collection (src/content/config.ts) with Zod schema: title, date, summary, tags, draft
- Blog listing page (/blog/) with Substack embed and post cards
- Individual post template (/blog/[slug]/) with prose styles tuned for dark theme
- Sample post: weekly cyber news for 2026-05-15 (FortiOS RCE, Scattered Spider, CISA ICS advisory)
- Header updated: Blog link in desktop + mobile nav; logo links to home
- weekly_post.py: fetches top 5 items from THN/Krebs/CISA RSS feeds, calls Claude API, writes .md, runs git add/commit/push automatically
- requirements.txt, .env.example, README automation setup section