### PR TITLE
fix(weekly-post)

### DIFF
--- a/weekly_post.py
+++ b/weekly_post.py
@@ -180,7 +180,11 @@ def call_model(user_prompt: str) -> str:
         contents=user_prompt,
         config=types.GenerateContentConfig(
             system_instruction=SYSTEM_PROMPT,
-            max_output_tokens=2048,
+            max_output_tokens=8192,
+            # Disable thinking — this is a structured writing task that doesn't
+            # benefit from it, and thinking tokens would otherwise consume the
+            # output budget and truncate the post mid-frontmatter.
+            thinking_config=types.ThinkingConfig(thinking_budget=0),
         ),
     )
     text = (response.text or "").strip()


### PR DESCRIPTION
…ncation

gemini-2.5-flash has built-in thinking that burns tokens before generating visible output. With max_output_tokens=2048 the thinking budget ate nearly the entire quota, leaving only 4 lines of frontmatter — which broke the Astro build. Fixes:
- thinking_budget=0: disable thinking (unnecessary for structured writing)
- max_output_tokens=8192: enough headroom for a 900-word post with margin

