### PR TITLE
feat(contact): add GitHub profile links across the site

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -11,12 +11,12 @@
                     </p>
                 </div>
 
-                <div class="grid md:grid-cols-2 gap-8 mb-12">
+                <div class="grid md:grid-cols-3 gap-8 mb-12">
                     <!-- Email -->
                     <div class="card text-center group hover:scale-105 transition-transform duration-300">
                         <div class="text-4xl mb-4">📧</div>
                         <h3 class="text-xl font-bold mb-2 text-primary-400">Email</h3>
-                        <a href="mailto:juandresrodca@gmail.com" class="text-gray-300 hover:text-primary-400 transition-colors">
+                        <a href="mailto:juandresrodca@gmail.com" class="text-gray-300 hover:text-primary-400 transition-colors break-all">
                             juandresrodca@gmail.com
                         </a>
                     </div>
@@ -25,8 +25,21 @@
                     <div class="card text-center group hover:scale-105 transition-transform duration-300">
                         <div class="text-4xl mb-4">💼</div>
                         <h3 class="text-xl font-bold mb-2 text-primary-400">LinkedIn</h3>
-                        <a href="https://www.linkedin.com/in/juan-andres-rodriguez-itil" target="_blank" class="text-gray-300 hover:text-primary-400 transition-colors">
+                        <a href="https://www.linkedin.com/in/juan-andres-rodriguez-itil" target="_blank" rel="noopener noreferrer" class="text-gray-300 hover:text-primary-400 transition-colors">
                             Connect with me
+                        </a>
+                    </div>
+
+                    <!-- GitHub -->
+                    <div class="card text-center group hover:scale-105 transition-transform duration-300">
+                        <div class="text-4xl mb-4">
+                            <svg class="w-10 h-10 mx-auto text-gray-200" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                                <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"/>
+                            </svg>
+                        </div>
+                        <h3 class="text-xl font-bold mb-2 text-primary-400">GitHub</h3>
+                        <a href="https://github.com/juandresrodca" target="_blank" rel="noopener noreferrer" class="text-gray-300 hover:text-primary-400 transition-colors">
+                            See my code & projects
                         </a>
                     </div>
                 </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -10,6 +10,31 @@
                         <a href="https://tailwindcss.com" target="_blank" class="text-primary-400 hover:text-primary-300 transition-colors">Tailwind CSS</a>
                     </p>
                 </div>
+
+                <!-- Social links -->
+                <div class="flex items-center space-x-5">
+                    <a href="https://github.com/juandresrodca" target="_blank" rel="noopener noreferrer"
+                       aria-label="GitHub profile"
+                       class="text-gray-400 hover:text-primary-400 transition-colors">
+                        <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"/>
+                        </svg>
+                    </a>
+                    <a href="https://www.linkedin.com/in/juan-andres-rodriguez-itil" target="_blank" rel="noopener noreferrer"
+                       aria-label="LinkedIn profile"
+                       class="text-gray-400 hover:text-primary-400 transition-colors">
+                        <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+                        </svg>
+                    </a>
+                    <a href="mailto:juandresrodca@gmail.com"
+                       aria-label="Email Juan"
+                       class="text-gray-400 hover:text-primary-400 transition-colors">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                        </svg>
+                    </a>
+                </div>
             </div>
         </div>
     </footer>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -18,12 +18,19 @@
                 </div>
 
                 <!-- CTA buttons with delay -->
-                <div class="animate-slide-up space-x-4" style="animation-delay: 0.6s;">
+                <div class="animate-slide-up flex flex-wrap items-center justify-center gap-4" style="animation-delay: 0.6s;">
                     <a href="#projects" class="btn-primary inline-block">
                         View My Work
                     </a>
                     <a href="#contact" class="btn-secondary inline-block">
                         Get In Touch
+                    </a>
+                    <a href="https://github.com/juandresrodca" target="_blank" rel="noopener noreferrer"
+                       aria-label="GitHub profile"
+                       class="inline-flex items-center justify-center w-12 h-12 rounded-full border border-gray-600 text-gray-300 hover:text-white hover:border-primary-400 hover:scale-110 transition-all duration-300">
+                        <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"/>
+                        </svg>
                     </a>
                 </div>
 


### PR DESCRIPTION
- Footer: GitHub, LinkedIn and email icon links
- Contact: third card linking to the GitHub profile (grid now 3 columns)
- Hero: circular GitHub icon button next to the CTA buttons

The GitHub profile was previously not linked anywhere on the site.

