### PR TITLE
redesign the visuals

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -1,42 +1,87 @@
 <!-- About Section -->
     <section id="about" class="scroll-reveal py-20 bg-dark-800 bg-opacity-20 relative">
         <div class="container mx-auto px-6">
-            <h2 class="section-title">About Me</h2>
+            <h2 class="section-title">About <em>Me</em></h2>
+            <div class="title-rule"></div>
 
             <div class="grid md:grid-cols-2 gap-12 items-center">
                 <div class="space-y-6">
                     <p class="text-lg text-gray-300 leading-relaxed">
-                        With <span class="text-primary-400 font-semibold">14+ years</span> of progressive experience in IT systems administration and technical support, I've supported over 3,000+ end-users across enterprise and government environments.
+                        With <span class="text-accent-400 font-semibold">14+ years</span> of progressive experience in IT systems administration and technical support, I've supported over 3,000+ end-users across enterprise and government environments.
                     </p>
 
                     <p class="text-lg text-gray-300 leading-relaxed">
-                        Currently working at <span class="text-secondary-500 font-semibold">Intel  Ireland</span>, supporting in a large-scale VM server migration project from VMware to Microsoft Hyper-V.
+                        Currently working at <span class="text-secondary-400 font-semibold">Intel  Ireland</span>, supporting in a large-scale VM server migration project from VMware to Microsoft Hyper-V.
                     </p>
 
                     <p class="text-lg text-gray-300 leading-relaxed">
-                        Now pursuing my passion for cybersecurity with <span class="text-primary-400 font-semibold">OSCP certification</span> in progress and hands-on experience with penetration testing through HackTheBox challenges.
+                        Now pursuing my passion for cybersecurity with <span class="text-accent-400 font-semibold">OSCP certification</span> in progress and hands-on experience with penetration testing through HackTheBox challenges.
                     </p>
 
-                    <div class="flex flex-wrap gap-4 pt-4">
-                        <span class="bg-primary-600/20 text-primary-400 px-3 py-1 rounded-full text-sm">ITIL v3 Certified</span>
-                        <span class="bg-secondary-600/20 text-secondary-400 px-3 py-1 rounded-full text-sm">OSCP In Progress</span>
-                        <span class="bg-purple-600/20 text-purple-400 px-3 py-1 rounded-full text-sm">Dublin, Ireland</span>
+                    <div class="flex flex-wrap gap-3 pt-4">
+                        <span class="chip chip-hot">ITIL v3 Certified</span>
+                        <span class="chip chip-hot">OSCP In Progress</span>
+                        <span class="chip">Dublin, Ireland</span>
                     </div>
                 </div>
 
                 <div class="flex justify-center">
-                    <div class="relative">
-                        <div class="w-80 h-80 bg-gradient-to-br from-primary-500 to-secondary-500 rounded-full p-1">
-                            <img
-                                src="/cv-juan/juan-profile.jpg"
-                                alt="Juan Rodriguez"
-                                class="w-full h-full object-cover rounded-full"
-                            />
-                        </div>
-                        <div class="absolute -top-4 -right-4 w-20 h-20 bg-primary-500 rounded-full animate-float opacity-20"></div>
-                        <div class="absolute -bottom-6 -left-6 w-16 h-16 bg-secondary-500 rounded-full animate-float opacity-30" style="animation-delay: 2s;"></div>
+                    <div class="portrait">
+                        <div class="portrait-ring" aria-hidden="true"></div>
+                        <img
+                            src="/cv-juan/juan-profile.jpg"
+                            alt="Juan Rodriguez"
+                            class="portrait-img"
+                        />
                     </div>
                 </div>
             </div>
         </div>
     </section>
+
+<style>
+    .chip {
+        font-family: 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 0.74rem;
+        padding: 6px 14px;
+        border-radius: 8px;
+        border: 1px solid rgba(148, 163, 184, 0.12);
+        color: #94a3b8;
+        background: rgba(148, 163, 184, 0.05);
+    }
+
+    .chip-hot {
+        border-color: rgba(34, 211, 238, 0.35);
+        color: #22d3ee;
+        background: rgba(34, 211, 238, 0.06);
+    }
+
+    .portrait {
+        position: relative;
+        width: 20rem;
+        height: 20rem;
+    }
+
+    /* Spinning conic gradient ring — replaces the static gradient border */
+    .portrait-ring {
+        position: absolute;
+        inset: -10px;
+        border-radius: 50%;
+        background: conic-gradient(from 180deg, #3b82f6, #22d3ee, transparent 60%, #3b82f6);
+        -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 calc(100% - 2px));
+        mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 calc(100% - 2px));
+        animation: ring-spin 14s linear infinite;
+    }
+
+    @keyframes ring-spin {
+        to { transform: rotate(360deg); }
+    }
+
+    .portrait-img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: 50%;
+        border: 1px solid rgba(148, 163, 184, 0.12);
+    }
+</style>

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -1,7 +1,8 @@
     <!-- Contact Section -->
     <section id="contact" class="scroll-reveal py-20 bg-transparent">
         <div class="container mx-auto px-6">
-            <h2 class="section-title">Get In Touch</h2>
+            <h2 class="section-title">Get In <em>Touch</em></h2>
+            <div class="title-rule"></div>
 
             <div class="max-w-4xl mx-auto">
                 <div class="text-center mb-12">
@@ -13,35 +14,39 @@
 
                 <div class="grid md:grid-cols-3 gap-8 mb-12">
                     <!-- Email -->
-                    <div class="card text-center group hover:scale-105 transition-transform duration-300">
-                        <div class="text-4xl mb-4">📧</div>
-                        <h3 class="text-xl font-bold mb-2 text-primary-400">Email</h3>
-                        <a href="mailto:juandresrodca@gmail.com" class="text-gray-300 hover:text-primary-400 transition-colors break-all">
-                            juandresrodca@gmail.com
-                        </a>
-                    </div>
-
-                    <!-- LinkedIn -->
-                    <div class="card text-center group hover:scale-105 transition-transform duration-300">
-                        <div class="text-4xl mb-4">💼</div>
-                        <h3 class="text-xl font-bold mb-2 text-primary-400">LinkedIn</h3>
-                        <a href="https://www.linkedin.com/in/juan-andres-rodriguez-itil" target="_blank" rel="noopener noreferrer" class="text-gray-300 hover:text-primary-400 transition-colors">
-                            Connect with me
-                        </a>
-                    </div>
-
-                    <!-- GitHub -->
-                    <div class="card text-center group hover:scale-105 transition-transform duration-300">
-                        <div class="text-4xl mb-4">
-                            <svg class="w-10 h-10 mx-auto text-gray-200" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                                <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"/>
+                    <a href="mailto:juandresrodca@gmail.com" class="card-v2 block text-center">
+                        <div class="icon-chip" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                             </svg>
                         </div>
-                        <h3 class="text-xl font-bold mb-2 text-primary-400">GitHub</h3>
-                        <a href="https://github.com/juandresrodca" target="_blank" rel="noopener noreferrer" class="text-gray-300 hover:text-primary-400 transition-colors">
-                            See my code & projects
-                        </a>
-                    </div>
+                        <h3 class="text-lg font-bold mb-1 text-white">Email</h3>
+                        <span class="text-gray-400 text-sm break-all">juandresrodca@gmail.com</span>
+                    </a>
+
+                    <!-- LinkedIn -->
+                    <a href="https://www.linkedin.com/in/juan-andres-rodriguez-itil" target="_blank" rel="noopener noreferrer" class="card-v2 block text-center">
+                        <div class="icon-chip" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                                <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-4 0v7h-4v-7a6 6 0 0 1 6-6zM2 9h4v12H2z"/>
+                                <circle cx="4" cy="4" r="2"/>
+                            </svg>
+                        </div>
+                        <h3 class="text-lg font-bold mb-1 text-white">LinkedIn</h3>
+                        <span class="text-gray-400 text-sm">Connect with me</span>
+                    </a>
+
+                    <!-- GitHub -->
+                    <a href="https://github.com/juandresrodca" target="_blank" rel="noopener noreferrer" class="card-v2 block text-center">
+                        <div class="icon-chip" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                                <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.4 5.4 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65S8.93 17.38 9 18v4"/>
+                                <path d="M9 18c-4.51 2-5-2-7-2"/>
+                            </svg>
+                        </div>
+                        <h3 class="text-lg font-bold mb-1 text-white">GitHub</h3>
+                        <span class="text-gray-400 text-sm">See my code & projects</span>
+                    </a>
                 </div>
 
                 <div class="grid md:grid-cols-2 gap-8">
@@ -95,6 +100,26 @@
             </div>
         </div>
     </section>
+
+    <style>
+        .icon-chip {
+            width: 44px;
+            height: 44px;
+            margin: 0 auto 14px;
+            border-radius: 11px;
+            border: 1px solid rgba(148, 163, 184, 0.12);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(59, 130, 246, 0.08);
+            color: #22d3ee;
+        }
+
+        .icon-chip svg {
+            width: 20px;
+            height: 20px;
+        }
+    </style>
 
     <script is:inline>
         // Use Global Event Delegation to bypass Astro hydration/timing issues

--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -1,136 +1,192 @@
  <!-- Experience Section -->
     <section id="experience" class="scroll-reveal py-20 bg-transparent">
         <div class="container mx-auto px-6">
-            <h2 class="section-title">Professional Experience</h2>
+            <div class="max-w-3xl mx-auto">
+                <h2 class="section-title">Professional <em>Experience</em></h2>
+                <div class="title-rule"></div>
 
-            <div class="max-w-4xl mx-auto">
-                <div class="relative">
-                    <!-- Timeline line -->
-                    <div class="absolute left-8 top-0 bottom-0 w-px bg-gradient-to-b from-primary-500 to-secondary-500"></div>
-
-                    <!-- Experience items -->
-                    <div class="space-y-12">
-                        <!-- Intel Ireland -->
-                        <div class="timeline-item relative flex items-start">
-                            <div class="timeline-dot absolute left-6 w-4 h-4 bg-primary-500 rounded-full border-4 border-dark-900 z-10"></div>
-                            <div class="ml-20 card w-full">
-                                <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-4">
-                                    <h3 class="text-2xl text-secondary-500 font-semibold">IT Lab Support Agent</h3>
-                                    <span class="text-gray-400 font-semibold">2025 – 2026</span>
-                                </div>
-                                <p class="text-lg font-semibold text-secondary-400 mb-3">Intel Ireland</p>
-                                <p class="text-gray-300 mb-4">
-                                    Global IT Operations team providing hands-on technical support for critical laboratory environments and semiconductor research tools.
-                                </p>
-                                <ul class="space-y-2 text-gray-300 text-sm md:text-base">
-                                    <li class="flex items-start">
-                                        <span class="text-primary-400 mr-2 shrink-0">•</span>
-                                        <span>Played an active role in a large-scale VM and server migration project from VMware to Microsoft Hyper-V.</span>
-                                    </li>
-                                    <li class="flex items-start">
-                                        <span class="text-primary-400 mr-2 shrink-0">•</span>
-                                        <span>Provided reliable global support to Intel labs outside Ireland across different time zones.</span>
-                                    </li>
-                                    <li class="flex items-start">
-                                        <span class="text-primary-400 mr-2 shrink-0">•</span>
-                                        <span>Maintained lab infrastructure compliance with strict operational, security, and performance standards.</span>
-                                    </li>
-                                </ul>
-                            </div>
+                <div class="xp">
+                    <!-- Intel Ireland -->
+                    <div class="timeline-item xp-item">
+                        <div class="xp-dot xp-dot-live"></div>
+                        <div class="xp-head">
+                            <h3>IT Lab Support Agent</h3>
+                            <span class="xp-date">2025 – 2026</span>
                         </div>
+                        <p class="xp-org">Intel Ireland</p>
+                        <p class="xp-desc">
+                            Global IT Operations team providing hands-on technical support for critical laboratory environments and semiconductor research tools.
+                        </p>
+                        <ul class="xp-list">
+                            <li>Played an active role in a large-scale VM and server migration project from VMware to Microsoft Hyper-V.</li>
+                            <li>Provided reliable global support to Intel labs outside Ireland across different time zones.</li>
+                            <li>Maintained lab infrastructure compliance with strict operational, security, and performance standards.</li>
+                        </ul>
+                    </div>
 
-                        <!-- SAP Ireland -->
-                        <div class="timeline-item relative flex items-start">
-                            <div class="timeline-dot absolute left-6 w-4 h-4 bg-secondary-500 rounded-full border-4 border-dark-900 z-10"></div>
-                            <div class="ml-20 card w-full">
-                                <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-4">
-                                    <h3 class="text-2xl font-bold text-purple-400">ICT Technician</h3>
-                                    <span class="text-gray-400 font-semibold">2021 – 2025</span>
-                                </div>
-                                <p class="text-lg font-semibold text-primary-400 mb-3">SAP Ireland</p>
-                                <p class="text-gray-300 mb-4">
-                                    Bilingual (Spanish-English) technician for EMEA serving an extremely international client base.
-                                </p>
-                                <ul class="space-y-2 text-gray-300 text-sm md:text-base">
-                                    <li class="flex items-start">
-                                        <span class="text-secondary-400 mr-2 shrink-0">•</span>
-                                        <span>Managed ServiceNow ticket escalation processes, maintaining strict SLA compliance.</span>
-                                    </li>
-                                    <li class="flex items-start">
-                                        <span class="text-secondary-400 mr-2 shrink-0">•</span>
-                                        <span>Administered Trellix EDR platform for threat detection and enterprise security policies.</span>
-                                    </li>
-                                    <li class="flex items-start">
-                                        <span class="text-secondary-400 mr-2 shrink-0">•</span>
-                                        <span>Provided Azure AD administration, Autopilot, and SCCM configuration thorough migration to Intune.</span>
-                                    </li>
-                                    <li class="flex items-start">
-                                        <span class="text-secondary-400 mr-2 shrink-0">•</span>
-                                        <span>Delivered SAP HANA L1 support and Citrix Virtual Desktop Infrastructure (VDI) management.</span>
-                                    </li>
-                                </ul>
-                            </div>
+                    <!-- SAP Ireland -->
+                    <div class="timeline-item xp-item">
+                        <div class="xp-dot"></div>
+                        <div class="xp-head">
+                            <h3>ICT Technician</h3>
+                            <span class="xp-date">2021 – 2025</span>
                         </div>
+                        <p class="xp-org">SAP Ireland</p>
+                        <p class="xp-desc">
+                            Bilingual (Spanish-English) technician for EMEA serving an extremely international client base.
+                        </p>
+                        <ul class="xp-list">
+                            <li>Managed ServiceNow ticket escalation processes, maintaining strict SLA compliance.</li>
+                            <li>Administered Trellix EDR platform for threat detection and enterprise security policies.</li>
+                            <li>Provided Azure AD administration, Autopilot, and SCCM configuration thorough migration to Intune.</li>
+                            <li>Delivered SAP HANA L1 support and Citrix Virtual Desktop Infrastructure (VDI) management.</li>
+                        </ul>
+                    </div>
 
-                        <!-- Arnaldo C. Castro S.A -->
-                        <div class="timeline-item relative flex items-start">
-                            <div class="timeline-dot absolute left-6 w-4 h-4 bg-purple-500 rounded-full border-4 border-dark-900 z-10"></div>
-                            <div class="ml-20 card w-full">
-                                <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-4">
-                                    <h3 class="text-2xl font-bold text-purple-400">Senior Technical Support Operative</h3>
-                                    <span class="text-gray-400 font-semibold">2017 – 2020</span>
-                                </div>
-                                <p class="text-lg font-semibold text-secondary-400 mb-3">Arnaldo C. Castro S.A</p>
-                                <p class="text-gray-300 mb-4">
-                                    IT operations for Uruguay's Ministry of Industry, Energy and Mining.
-                                </p>
-                                <ul class="space-y-2 text-gray-300 text-sm md:text-base">
-                                    <li class="flex items-start">
-                                        <span class="text-purple-400 mr-2 shrink-0">•</span>
-                                        <span>Successfully passed ITIL v3 certification to meet strict government regulatory requirements.</span>
-                                    </li>
-                                    <li class="flex items-start">
-                                        <span class="text-purple-400 mr-2 shrink-0">•</span>
-                                        <span>Designed a systematic SQL database schema to inventory 900+ devices across 7 buildings in 5 weeks.</span>
-                                    </li>
-                                    <li class="flex items-start">
-                                        <span class="text-purple-400 mr-2 shrink-0">•</span>
-                                        <span>Supervised infrastructure updates, VoIP deployments, and cross-platform server administration.</span>
-                                    </li>
-                                </ul>
-                            </div>
+                    <!-- Arnaldo C. Castro S.A -->
+                    <div class="timeline-item xp-item">
+                        <div class="xp-dot"></div>
+                        <div class="xp-head">
+                            <h3>Senior Technical Support Operative</h3>
+                            <span class="xp-date">2017 – 2020</span>
                         </div>
+                        <p class="xp-org">Arnaldo C. Castro S.A</p>
+                        <p class="xp-desc">
+                            IT operations for Uruguay's Ministry of Industry, Energy and Mining.
+                        </p>
+                        <ul class="xp-list">
+                            <li>Successfully passed ITIL v3 certification to meet strict government regulatory requirements.</li>
+                            <li>Designed a systematic SQL database schema to inventory 900+ devices across 7 buildings in 5 weeks.</li>
+                            <li>Supervised infrastructure updates, VoIP deployments, and cross-platform server administration.</li>
+                        </ul>
+                    </div>
 
-                        <!-- SONDA Uruguay -->
-                        <div class="timeline-item relative flex items-start">
-                            <div class="timeline-dot absolute left-6 w-4 h-4 bg-primary-500 rounded-full border-4 border-dark-900 z-10"></div>
-                            <div class="ml-20 card w-full">
-                                <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-4">
-                                    <h3 class="text-2xl font-bold text-primary-400">L2 Tech & Symantec Console Admin</h3>
-                                    <span class="text-gray-400 font-semibold">2011 – 2017</span>
-                                </div>
-                                <p class="text-lg font-semibold text-secondary-400 mb-3">SONDA Uruguay</p>
-                                <p class="text-gray-300 mb-4">
-                                    Started as Junior Technician and progressed to Level 2 support for ANCAP, Uruguay's semi-state energy body.
-                                </p>
-                                <ul class="space-y-2 text-gray-300 text-sm md:text-base">
-                                    <li class="flex items-start">
-                                        <span class="text-primary-400 mr-2 shrink-0">•</span>
-                                        <span>Monitored security alerts across 3,000+ computers via the Symantec threat console.</span>
-                                    </li>
-                                    <li class="flex items-start">
-                                        <span class="text-primary-400 mr-2 shrink-0">•</span>
-                                        <span>Deployed threat patches and maintained antivirus client compliance across the network.</span>
-                                    </li>
-                                    <li class="flex items-start">
-                                        <span class="text-primary-400 mr-2 shrink-0">•</span>
-                                        <span>Provided initial hardware repair and L1 support, excelling in rapid issue resolution.</span>
-                                    </li>
-                                </ul>
-                            </div>
+                    <!-- SONDA Uruguay -->
+                    <div class="timeline-item xp-item">
+                        <div class="xp-dot"></div>
+                        <div class="xp-head">
+                            <h3>L2 Tech & Symantec Console Admin</h3>
+                            <span class="xp-date">2011 – 2017</span>
                         </div>
+                        <p class="xp-org">SONDA Uruguay</p>
+                        <p class="xp-desc">
+                            Started as Junior Technician and progressed to Level 2 support for ANCAP, Uruguay's semi-state energy body.
+                        </p>
+                        <ul class="xp-list">
+                            <li>Monitored security alerts across 3,000+ computers via the Symantec threat console.</li>
+                            <li>Deployed threat patches and maintained antivirus client compliance across the network.</li>
+                            <li>Provided initial hardware repair and L1 support, excelling in rapid issue resolution.</li>
+                        </ul>
                     </div>
                 </div>
             </div>
         </div>
     </section>
+
+<style>
+  .xp {
+    position: relative;
+  }
+
+  .xp::before {
+    content: '';
+    position: absolute;
+    left: 7px;
+    top: 6px;
+    bottom: 6px;
+    width: 1px;
+    background: linear-gradient(180deg, #3b82f6, rgba(59, 130, 246, 0.06));
+  }
+
+  .xp-item {
+    position: relative;
+    padding-left: 44px;
+    margin-bottom: 40px;
+  }
+
+  .xp-item:last-child {
+    margin-bottom: 0;
+  }
+
+  .xp-dot {
+    position: absolute;
+    left: 0;
+    top: 6px;
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    background: #0b1120;
+    border: 2px solid #3b82f6;
+    z-index: 1;
+  }
+
+  .xp-dot-live::after {
+    content: '';
+    position: absolute;
+    inset: 2px;
+    border-radius: 50%;
+    background: #3b82f6;
+    animation: xp-pulse 2.4s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+  }
+
+  @keyframes xp-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.5); }
+    50% { box-shadow: 0 0 0 6px rgba(59, 130, 246, 0); }
+  }
+
+  .xp-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px 16px;
+    margin-bottom: 4px;
+  }
+
+  .xp-head h3 {
+    font-size: 1.25rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: #e2e8f0;
+  }
+
+  .xp-date {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.75rem;
+    color: #64748b;
+    margin-left: auto;
+  }
+
+  .xp-org {
+    font-size: 0.95rem;
+    color: #22d3ee;
+    font-weight: 600;
+    margin-bottom: 10px;
+  }
+
+  .xp-desc {
+    color: #94a3b8;
+    font-size: 0.95rem;
+    margin-bottom: 10px;
+  }
+
+  .xp-list {
+    list-style: none;
+  }
+
+  .xp-list li {
+    color: #94a3b8;
+    font-size: 0.92rem;
+    padding-left: 18px;
+    position: relative;
+    margin-bottom: 6px;
+  }
+
+  .xp-list li::before {
+    content: '▸';
+    position: absolute;
+    left: 0;
+    top: 2px;
+    color: #3b82f6;
+    font-size: 0.8rem;
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,8 +2,8 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-dark-900/80 backdrop-blur-md border-b border-gray-800">
         <nav class="container mx-auto px-6 py-4">
             <div class="flex justify-between items-center">
-                <a href={`${import.meta.env.BASE_URL}`} class="text-2xl font-bold text-gradient hover:opacity-80 transition-opacity">
-                    Juan Rodriguez
+                <a href={`${import.meta.env.BASE_URL}`} class="text-2xl font-extrabold tracking-tight text-white hover:opacity-80 transition-opacity">
+                    <span class="text-gradient">J</span>uan Rodriguez
                 </a>
 
                 <!-- Desktop Menu -->

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -3,8 +3,9 @@
             <div class="max-w-4xl mx-auto">
                 <!-- Typewriter effect greeting -->
                 <div class="animate-fade-in">
+                    <span class="hero-prompt"><span class="hp-accent">$</span> whoami <span class="hp-accent">→</span></span>
                     <h1 class="text-6xl md:text-8xl font-bold mb-6 text-gradient typewriter-header">
-                        <span id="typed-text">Hi, I'm Juan</span><span class="cursor">|</span>
+                        <span id="typed-text">Hi, I'm Juan</span><span class="cursor" aria-hidden="true"></span>
                     </h1>
                 </div>
 
@@ -19,10 +20,10 @@
 
                 <!-- CTA buttons with delay -->
                 <div class="animate-slide-up flex flex-wrap items-center justify-center gap-4" style="animation-delay: 0.6s;">
-                    <a href="#projects" class="btn-primary inline-block">
-                        View My Work
+                    <a href="#projects" class="btn-cta">
+                        View My Work <span class="arr">→</span>
                     </a>
-                    <a href="#contact" class="btn-secondary inline-block">
+                    <a href="#contact" class="btn-cta-ghost">
                         Get In Touch
                     </a>
                     <a href="https://github.com/juandresrodca" target="_blank" rel="noopener noreferrer"
@@ -47,15 +48,31 @@
     </section>
 
 <style>
+    .hero-prompt {
+        font-family: 'JetBrains Mono', ui-monospace, monospace;
+        font-size: clamp(0.85rem, 1.8vw, 1.05rem);
+        color: #64748b;
+        display: block;
+        margin-bottom: 20px;
+    }
+
+    .hp-accent {
+        color: #22d3ee;
+    }
+
+    /* Block cursor bar — replaces the green "|" character */
     .cursor {
-        animation: blink 0.7s infinite;
-        color: #00ff41;
-        font-weight: bold;
+        display: inline-block;
+        width: 0.09em;
+        height: 0.85em;
+        background: #22d3ee;
+        margin-left: 0.06em;
+        transform: translateY(0.08em);
+        animation: blink 1.1s steps(1) infinite;
     }
 
     @keyframes blink {
-        0%, 50% { opacity: 1; }
-        51%, 100% { opacity: 0; }
+        50% { opacity: 0; }
     }
 </style>
 

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -73,7 +73,8 @@ const staticProjects = [
 ---
 <section id="projects" class="scroll-reveal py-20 bg-dark-800 bg-opacity-40">
     <div class="container mx-auto px-6">
-        <h2 class="section-title">My Projects and Write-ups</h2>
+        <h2 class="section-title">My Projects and <em>Write-ups</em></h2>
+        <div class="title-rule"></div>
         <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
             {sortedWriteups.map((writeup) => (
                 <div class="card glow-card tilt-card group hover:scale-105 transition-transform duration-300">

--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -42,7 +42,8 @@ const SKILLS = [
 <!-- Skills Section -->
 <section id="skills" class="scroll-reveal py-20 bg-transparent">
   <div class="container mx-auto px-6">
-    <h2 class="section-title">Technical Skills</h2>
+    <h2 class="section-title">Technical <em>Skills</em></h2>
+    <div class="title-rule"></div>
     <div class="max-w-6xl mx-auto">
 
       <!-- ══ MOBILE: original card grid (hidden on md+) ══ -->

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,6 @@
 ---
+import '../styles/global.css';
+
 export interface Props {
   title: string;
   description?: string;
@@ -59,7 +61,7 @@ const socialImageURL = new URL(image, Astro.site);
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
   </head>
   <body class="font-inter bg-dark-900 text-white overflow-x-hidden">
     <!-- Scroll Progress Bar -->

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  /* Motion system: one quint ease-out curve, two durations */
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --dur-fast: 0.25s;
+  --dur: 0.6s;
+}
+
 @layer base {
   * {
     box-sizing: border-box;
@@ -26,17 +33,29 @@
     @apply border-2 border-primary-600 text-primary-600 hover:bg-primary-600 hover:text-white font-semibold py-3 px-6 rounded-lg transition-all duration-300;
   }
 
+  /* Section titles: white heading with one gradient accent word (in <em>)
+     and a thin gradient rule below — replaces the old neon-pulse glow. */
   .section-title {
-    @apply text-4xl md:text-5xl font-bold text-center mb-12 text-gradient;
-    text-shadow:
-      0 0 7px rgba(59, 130, 246, 0.6),
-      0 0 20px rgba(59, 130, 246, 0.4),
-      0 0 40px rgba(59, 130, 246, 0.2);
-    animation: neon-pulse 3s ease-in-out infinite alternate;
+    @apply text-3xl md:text-4xl font-extrabold text-white;
+    letter-spacing: -0.03em;
+    line-height: 1.15;
+  }
+
+  .section-title em {
+    font-style: normal;
+    @apply bg-gradient-to-r from-primary-500 to-accent-400 bg-clip-text text-transparent;
+  }
+
+  .title-rule {
+    width: 64px;
+    height: 3px;
+    border-radius: 2px;
+    margin: 18px 0 56px;
+    background: linear-gradient(90deg, #3b82f6, #22d3ee);
   }
 
   .text-gradient {
-    @apply bg-gradient-to-r from-primary-400 to-secondary-500 bg-clip-text text-transparent;
+    @apply bg-gradient-to-r from-primary-500 to-accent-400 bg-clip-text text-transparent;
   }
 
   .card {
@@ -80,15 +99,15 @@
 }
 
 #about {
-  background: rgba(31, 41, 55, 0.15) !important;
+  background: rgba(17, 26, 46, 0.45) !important;
   position: relative;
 }
 
-/* ====== SCROLL REVEAL ANIMATIONS ====== */
+/* ====== SCROLL REVEAL ANIMATIONS — quint ease-out curve ====== */
 .scroll-reveal {
   opacity: 0;
-  transform: translateY(40px);
-  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+  transform: translateY(28px);
+  transition: opacity var(--dur) var(--ease-out), transform var(--dur) var(--ease-out);
 }
 
 .scroll-reveal.revealed {
@@ -158,19 +177,20 @@
   transform: scaleX(0);
 }
 
-/* ====== TEXT SHADOW HOVER EFFECTS ON NAV LINKS ====== */
+/* ====== NAV LINKS — mono type, soft hover ====== */
 .nav-link {
-  --h: 1.2em;
-  line-height: var(--h);
-  color: transparent;
-  text-shadow: 0 0 #fff, 0 var(--h) #3b82f6;
-  overflow: hidden;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.85rem;
+  color: #94a3b8;
   display: inline-block;
-  transition: 0.3s;
+  padding: 8px 12px;
+  border-radius: 8px;
+  transition: color var(--dur-fast) var(--ease-out), background-color var(--dur-fast) var(--ease-out);
 }
 
 .nav-link:hover {
-  text-shadow: 0 calc(-1 * var(--h)) #fff, 0 0 #3b82f6;
+  color: #e2e8f0;
+  background-color: rgba(59, 130, 246, 0.1);
 }
 
 /* ====== CSS SCROLL-DRIVEN PARALLAX FOR BACKGROUND ====== */
@@ -221,19 +241,103 @@
   50% { box-shadow: 0 0 25px rgba(59, 130, 246, 0.8); }
 }
 
-/* ====== NEON GLOW TEXT ====== */
-@keyframes neon-pulse {
-  from {
-    text-shadow:
-      0 0 7px rgba(59, 130, 246, 0.6),
-      0 0 20px rgba(59, 130, 246, 0.4),
-      0 0 40px rgba(59, 130, 246, 0.2);
+/* ====== SURFACE CARD (v2) — contact cards, lift-not-zoom hover ====== */
+.card-v2 {
+  background: linear-gradient(180deg, #16213a, #111a2e);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 14px;
+  padding: 26px;
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out),
+    box-shadow var(--dur-fast) var(--ease-out);
+}
+
+.card-v2::before {
+  /* inner top edge highlight */
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 12%;
+  right: 12%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(148, 163, 184, 0.35), transparent);
+}
+
+.card-v2:hover {
+  transform: translateY(-4px);
+  border-color: rgba(59, 130, 246, 0.45);
+  box-shadow: 0 18px 40px -18px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(59, 130, 246, 0.08);
+}
+
+/* ====== HERO CTA BUTTONS — lift + arrow slide instead of zoom ====== */
+.btn-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  background: linear-gradient(135deg, #2563eb, #0891b2);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 13px 26px;
+  border-radius: 10px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18), 0 8px 24px -8px rgba(37, 99, 235, 0.5);
+  transition: transform var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out);
+}
+
+.btn-cta:hover {
+  transform: translateY(-2px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18), 0 14px 32px -8px rgba(37, 99, 235, 0.65);
+}
+
+.btn-cta .arr {
+  transition: transform var(--dur-fast) var(--ease-out);
+}
+
+.btn-cta:hover .arr {
+  transform: translateX(4px);
+}
+
+.btn-cta-ghost {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: #94a3b8;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 13px 26px;
+  border-radius: 10px;
+  transition: transform var(--dur-fast) var(--ease-out), border-color var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out);
+}
+
+.btn-cta-ghost:hover {
+  border-color: rgba(59, 130, 246, 0.45);
+  color: #e2e8f0;
+  transform: translateY(-2px);
+}
+
+/* ====== REDUCED MOTION — hard accessibility constraint ====== */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
-  to {
-    text-shadow:
-      0 0 10px rgba(59, 130, 246, 0.8),
-      0 0 30px rgba(59, 130, 246, 0.5),
-      0 0 60px rgba(59, 130, 246, 0.3);
+
+  .scroll-reveal,
+  .scroll-reveal-stagger > *,
+  .timeline-item {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  #background-canvas {
+    display: none;
   }
 }
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -6,19 +6,33 @@ export default {
       colors: {
         primary: {
           50: '#eff6ff',
+          300: '#93c5fd',
+          400: '#60a5fa',
           500: '#3b82f6',
           600: '#2563eb',
           700: '#1d4ed8',
           900: '#1e3a8a',
         },
         secondary: {
+          400: '#34d399',
           500: '#10b981',
           600: '#059669',
         },
+        accent: {
+          400: '#22d3ee',
+        },
         dark: {
+          600: '#4b5563',
+          700: '#374151',
           800: '#1f2937',
-          900: '#111827',
+          850: '#16213a',
+          875: '#111a2e',
+          900: '#0b1120',
         }
+      },
+      fontFamily: {
+        inter: ['Inter', 'sans-serif'],
+        mono: ['JetBrains Mono', 'ui-monospace', 'monospace'],
       },
       animation: {
         'fade-in': 'fadeIn 0.8s ease-out',


### PR DESCRIPTION
- Import global.css in Layout (was never loaded — card, glow, reveal and title styles were dead code on the live site)
- Section titles: neon pulse replaced with white heading + gradient accent word and thin gradient underline rule
- One blue-to-cyan accent gradient across name, titles and primary CTA
- JetBrains Mono added for nav links, hero "$ whoami" prompt, dates and chips
- Hero: terminal prompt above the big typewriter, block cursor, new CTA buttons with lift + arrow-slide hover, deeper background (#0b1120)
- About: mono chips and spinning conic-gradient ring around the portrait
- Experience: unified timeline (white titles, cyan org, mono dates, live pulse dot on current role)
- Contact: surface cards with line SVG icons; forms untouched
- Motion system: quint ease-out curve + prefers-reduced-motion support
- Projects and Skills sections keep their original design