### PR TITLE
add Security Services section promoting Upwork pentest gig

### DIFF
--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -1,0 +1,232 @@
+<!-- Services Section — freelance security services strip -->
+    <section id="services" class="scroll-reveal py-20 bg-transparent">
+        <div class="container mx-auto px-6">
+            <div class="max-w-5xl mx-auto">
+                <h2 class="section-title">Security <em>Services</em></h2>
+                <div class="title-rule"></div>
+
+                <div class="svc-card">
+                    <div class="svc-body">
+                        <span class="svc-badge">
+                            <span class="svc-badge-dot" aria-hidden="true"></span>
+                            Available for freelance engagements
+                        </span>
+
+                        <h3 class="svc-title">Professional Penetration Test &amp; Vulnerability Assessment</h3>
+
+                        <p class="svc-desc">
+                            Independent security assessment for your web application, network or infrastructure —
+                            delivered off-hours, NDA-friendly, with a report your team can act on immediately.
+                        </p>
+
+                        <ul class="svc-list">
+                            <li>Manual + automated testing aligned with OWASP methodology</li>
+                            <li>Professional report: executive summary, CVSS-scored findings, evidence</li>
+                            <li>Clear, prioritized remediation guidance for every finding</li>
+                        </ul>
+
+                        <div class="svc-tags">
+                            <span class="svc-tag">OWASP</span>
+                            <span class="svc-tag">CVSS Scoring</span>
+                            <span class="svc-tag">Web &amp; Network</span>
+                            <span class="svc-tag">NDA Friendly</span>
+                        </div>
+                    </div>
+
+                    <div class="svc-cta">
+                        <a
+                            href="https://www.upwork.com/services/product/development-it-a-professional-penetration-test-and-vulnerability-assessment-report-2076356461356142581"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="svc-btn"
+                        >
+                            <svg class="svc-btn-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                <path d="M18.561 13.158c-1.102 0-2.135-.467-3.074-1.227l.228-1.076.008-.042c.207-1.143.849-3.06 2.839-3.06a2.705 2.705 0 0 1 2.703 2.703 2.707 2.707 0 0 1-2.704 2.702zm0-8.14c-2.539 0-4.51 1.649-5.31 4.366-1.22-1.834-2.148-4.036-2.687-5.892H7.828v7.112c-.002 1.406-1.141 2.546-2.547 2.548-1.405-.002-2.543-1.143-2.545-2.548V3.492H0v7.112c0 2.914 2.37 5.303 5.281 5.303 2.913 0 5.283-2.389 5.283-5.303v-1.19c.529 1.107 1.182 2.229 1.974 3.221l-1.673 7.873h2.797l1.213-5.71c1.063.679 2.285 1.109 3.686 1.109 3 0 5.439-2.452 5.439-5.45 0-3-2.439-5.439-5.439-5.439z"/>
+                            </svg>
+                            Order on Upwork
+                        </a>
+                        <span class="svc-cta-note">Escrow-protected payment via Upwork</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+<style>
+    .svc-card {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 32px;
+        align-items: center;
+        background: linear-gradient(180deg, #16213a, #111a2e);
+        border: 1px solid rgba(20, 168, 0, 0.25);
+        border-radius: 16px;
+        padding: 34px 38px;
+        position: relative;
+        overflow: hidden;
+        transition:
+            transform 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+            border-color 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+            box-shadow 0.25s cubic-bezier(0.22, 1, 0.36, 1);
+    }
+
+    .svc-card::before {
+        /* inner top edge highlight, tinted toward the Upwork green */
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 10%;
+        right: 10%;
+        height: 1px;
+        background: linear-gradient(90deg, transparent, rgba(108, 219, 121, 0.45), transparent);
+    }
+
+    .svc-card:hover {
+        transform: translateY(-4px);
+        border-color: rgba(20, 168, 0, 0.5);
+        box-shadow: 0 18px 40px -18px rgba(0, 0, 0, 0.6), 0 0 32px -12px rgba(20, 168, 0, 0.35);
+    }
+
+    .svc-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-family: 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 0.72rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #6cdb79;
+        border: 1px solid rgba(108, 219, 121, 0.35);
+        background: rgba(20, 168, 0, 0.08);
+        padding: 6px 14px;
+        border-radius: 99px;
+        margin-bottom: 18px;
+    }
+
+    .svc-badge-dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: #6cdb79;
+        animation: svc-pulse 2.4s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+    }
+
+    @keyframes svc-pulse {
+        0%, 100% { box-shadow: 0 0 0 0 rgba(108, 219, 121, 0.5); }
+        50% { box-shadow: 0 0 0 6px rgba(108, 219, 121, 0); }
+    }
+
+    .svc-title {
+        font-size: 1.45rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        color: #e2e8f0;
+        margin-bottom: 10px;
+    }
+
+    .svc-desc {
+        color: #94a3b8;
+        font-size: 0.98rem;
+        max-width: 560px;
+        margin-bottom: 16px;
+    }
+
+    .svc-list {
+        list-style: none;
+        margin-bottom: 18px;
+    }
+
+    .svc-list li {
+        color: #94a3b8;
+        font-size: 0.92rem;
+        padding-left: 18px;
+        position: relative;
+        margin-bottom: 6px;
+    }
+
+    .svc-list li::before {
+        content: '▸';
+        position: absolute;
+        left: 0;
+        top: 2px;
+        color: #6cdb79;
+        font-size: 0.8rem;
+    }
+
+    .svc-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .svc-tag {
+        font-family: 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 0.68rem;
+        color: #94a3b8;
+        border: 1px solid rgba(148, 163, 184, 0.15);
+        background: rgba(148, 163, 184, 0.05);
+        padding: 4px 10px;
+        border-radius: 6px;
+    }
+
+    .svc-cta {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 12px;
+        min-width: 220px;
+    }
+
+    .svc-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        background: #14a800;
+        color: #fff;
+        font-weight: 700;
+        font-size: 1rem;
+        padding: 15px 30px;
+        border-radius: 10px;
+        white-space: nowrap;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 8px 24px -8px rgba(20, 168, 0, 0.55);
+        transition:
+            transform 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+            box-shadow 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+            background 0.25s cubic-bezier(0.22, 1, 0.36, 1);
+    }
+
+    .svc-btn:hover {
+        background: #16b800;
+        transform: translateY(-2px);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 14px 32px -8px rgba(20, 168, 0, 0.7);
+    }
+
+    .svc-btn-icon {
+        width: 22px;
+        height: 22px;
+        flex-shrink: 0;
+    }
+
+    .svc-cta-note {
+        font-family: 'JetBrains Mono', ui-monospace, monospace;
+        font-size: 0.68rem;
+        color: #64748b;
+        text-align: center;
+    }
+
+    @media (max-width: 820px) {
+        .svc-card {
+            grid-template-columns: 1fr;
+            padding: 28px 24px;
+        }
+
+        .svc-cta {
+            align-items: stretch;
+            min-width: 0;
+        }
+
+        .svc-btn {
+            justify-content: center;
+        }
+    }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import Hero from '../components/Hero.astro';
 import About from '../components/About.astro';
 import Experience from '../components/Experience.astro';
 import Projects from '../components/Projects.astro';
+import Services from '../components/Services.astro';
 import Skills from '../components/Skills.astro';
 import Contact from '../components/Contact.astro';
 import Footer from '../components/Footer.astro';
@@ -19,6 +20,7 @@ import BackgroundAnimation from '../components/BackgroundAnimation.astro';
     <About />
     <Experience />
     <Projects />
+    <Services />
     <Skills />
     <Contact />
   </main>


### PR DESCRIPTION
New strip between Projects and Skills: pulsing availability badge, service description with OWASP/CVSS deliverable bullets, mono tag chips, and an Upwork-green CTA linking to the penetration test gig with an escrow-protection trust note. Responsive: stacks to one column with a full-width button on mobile.