### PR TITLE
fix(blog): nav anchors and background animation on blog pages

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,12 +8,12 @@
 
                 <!-- Desktop Menu -->
                 <ul class="hidden md:flex space-x-8">
-                    <li><a href="#home" class="nav-link">Home</a></li>
-                    <li><a href="#about" class="nav-link">About</a></li>
-                    <li><a href="#experience" class="nav-link">Experience</a></li>
-                    <li><a href="#projects" class="nav-link">Projects</a></li>
-                    <li><a href="#skills" class="nav-link">Skills</a></li>
-                    <li><a href="#contact" class="nav-link">Contact</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}#home`} class="nav-link">Home</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}#about`} class="nav-link">About</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}#experience`} class="nav-link">Experience</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}#projects`} class="nav-link">Projects</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}#skills`} class="nav-link">Skills</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}#contact`} class="nav-link">Contact</a></li>
                     <li><a href={`${import.meta.env.BASE_URL}blog/`} class="nav-link">Blog</a></li>
                 </ul>
 
@@ -26,12 +26,12 @@
             <!-- Mobile Menu -->
             <div id="mobile-menu" class="hidden md:hidden mt-4 pb-4 border-t border-gray-800">
                 <ul class="space-y-1 pt-3">
-                    <li><a href="#home" class="mobile-nav-link">Home</a></li>
-                    <li><a href="#about" class="mobile-nav-link">About</a></li>
-                    <li><a href="#experience" class="mobile-nav-link">Experience</a></li>
-                    <li><a href="#projects" class="mobile-nav-link">Projects</a></li>
-                    <li><a href="#skills" class="mobile-nav-link">Skills</a></li>
-                    <li><a href="#contact" class="mobile-nav-link">Contact</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}#home`} class="mobile-nav-link">Home</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}#about`} class="mobile-nav-link">About</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}#experience`} class="mobile-nav-link">Experience</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}#projects`} class="mobile-nav-link">Projects</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}#skills`} class="mobile-nav-link">Skills</a></li>
+                    <li><a href={`${import.meta.env.BASE_URL}#contact`} class="mobile-nav-link">Contact</a></li>
                     <li><a href={`${import.meta.env.BASE_URL}blog/`} class="mobile-nav-link">Blog</a></li>
                 </ul>
             </div>
@@ -88,5 +88,4 @@
       }
     });
   }
-</script>
 </script>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
+import BackgroundAnimation from '../../components/BackgroundAnimation.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => !data.draft);
@@ -30,7 +31,8 @@ function formatDate(date: Date) {
   type="article"
 >
   <Header />
-  <main class="min-h-screen bg-dark-900 pt-24 pb-20">
+  <BackgroundAnimation />
+  <main class="min-h-screen pt-24 pb-20">
     <div class="container mx-auto px-6 max-w-3xl">
 
       <!-- Back link -->

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
+import BackgroundAnimation from '../../components/BackgroundAnimation.astro';
 
 const allPosts = await getCollection('blog', ({ data }) => !data.draft);
 const posts = allPosts.sort(
@@ -23,7 +24,8 @@ function formatDate(date: Date) {
   description="Weekly cybersecurity signals, blue-team takes, and sysadmin field notes."
 >
   <Header />
-  <main class="min-h-screen bg-dark-900 pt-24 pb-20">
+  <BackgroundAnimation />
+  <main class="min-h-screen pt-24 pb-20">
     <div class="container mx-auto px-6 max-w-4xl">
 
       <!-- Page heading — left-aligned, editorial style -->


### PR DESCRIPTION
- Header anchor links (Home/About/Experience/Projects/Skills/Contact) now prefix BASE_URL so they navigate back to the index sections from /blog/ pages instead of resolving to non-existent local anchors. Applied to both desktop and mobile menus.
- Remove duplicate closing </script> tag in Header.astro.
- Render BackgroundAnimation canvas on blog listing and post pages, and drop the opaque bg-dark-900 on <main> (body already provides the background; the canvas sits at z-index -1 and was being covered).